### PR TITLE
removed extraneous csv

### DIFF
--- a/rss_urls.csv
+++ b/rss_urls.csv
@@ -1,6 +1,0 @@
-,publication,feed,is_uni_newspaper
-0,thehornettribune,https://asuhornettribune.com/feed/,1
-1,wvua23,https://www.wvua23.com/feed/,0
-2,deltadigitalnewservice,https://deltanewsservice.com/feed/,0
-3,cronkitenewsdistribution,https://cronkitenews.azpbs.org/rss-feed/,0
-4,elinde,https://indearizona.com/comments/feed/,0


### PR DESCRIPTION
running parse_url generates this csv. It had the entries for the 5 articles i used to test the code, and is not necessary to keep.